### PR TITLE
fix set-get @exports for 3.4 and below

### DIFF
--- a/parse_node/parse_class_declaration.ts
+++ b/parse_node/parse_class_declaration.ts
@@ -34,7 +34,7 @@ const getSettersAndGetters = (
         setGet.type
       )
 
-      exportText = `@export(${typeGodotName.result ?? "null"})\n`
+      exportText = `export(${typeGodotName.result ?? "null"}) `
     }
 
     if (setGet.kind === SyntaxKind.SetAccessor) {

--- a/parse_node/parse_get_accessor.ts
+++ b/parse_node/parse_get_accessor.ts
@@ -53,8 +53,7 @@ export class Test {
   `,
   expected: `
 class_name Test
-@export(String)
-var label setget label_set, label_get
+export(String) var label setget label_set, label_get
 func label_set(text: String):
   if self.LI:
     self.LI.text = text
@@ -78,12 +77,12 @@ export class Test {
   `,
   expected: `
 class_name Test
-@export(String)
-var label setget label_set, label_get
+export(String) var label setget label_set, label_get
 func label_set(_text: String):
   pass
 func label_get():
   return ""
+
 `,
 }
 
@@ -103,8 +102,7 @@ export class Test {
   `,
   expected: `
 class_name Test
-@export(String)
-var label setget label_set, label_get
+export(String) var label setget label_set, label_get
 func label_set(_text: String):
   pass
 func label_get():


### PR DESCRIPTION
#24 
There was an additional @ and Godot 3.4 didn't seem to like the new line.
Is some other version supporting these?