### PR TITLE
fix test paths

### DIFF
--- a/generate_library_defs/generate_base.ts
+++ b/generate_library_defs/generate_base.ts
@@ -253,12 +253,14 @@ export const buildBase = () => {
   )
 }
 
-export const baseContentForTests = `
+export function baseContentForTests() {
+  return `
 ${fs.readFileSync(
-  path.join(__dirname, "..", "_godot_defs", "static", "Vector2.d.ts")
+  path.join(process.cwd(), "_godot_defs", "static", "Vector2.d.ts")
 )}
 ${fs.readFileSync(
-  path.join(__dirname, "..", "_godot_defs", "static", "Vector3.d.ts")
+  path.join(process.cwd(), "_godot_defs", "static", "Vector3.d.ts")
 )}
 ${baseFileContent}
 `
+}

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -22,7 +22,7 @@ export const compileTs = (code: string, isAutoload: boolean): ParseNodeType => {
 
   const libDTs = ts.createSourceFile(
     "lib.d.ts",
-    baseContentForTests,
+    baseContentForTests(),
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TS


### PR DESCRIPTION
Making test paths relative to cwd to make them work with ts-node and the compiled js.
Also functioning it to not cause the read on module load.