### PR TITLE
Few changes regarding easier contributions to project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "godot_src"]
 	path = godot_src
-	url = git@github.com:godotengine/godot.git
+	url = https://github.com/godotengine/godot.git
 	branch = 3.4
 	shallow = true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+_godot_defs

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ts2gd",
       "version": "0.0.36",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
-        "husky": "^7.0.4",
         "tsutils": "^3.21.0",
         "xml2js": "^0.4.23"
       },
@@ -21,7 +21,9 @@
         "@types/chalk": "^2.2.0",
         "@types/node": "^16.11.9",
         "@types/xml2js": "^0.4.9",
+        "husky": "^7.0.4",
         "lint-staged": "^12.1.2",
+        "prettier": "^2.5.1",
         "ts-node": "^10.4.0",
         "ts-node-dev": "^1.1.8",
         "typescript": "^4.5.2"
@@ -578,6 +580,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
       "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
@@ -1122,6 +1125,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/readdirp": {
@@ -2083,7 +2098,8 @@
     "husky": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ=="
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -2471,6 +2487,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
     },
     "readdirp": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/xml2js": "^0.4.9",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
+    "prettier": "^2.5.1",
     "ts-node": "^10.4.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "^4.5.2"


### PR DESCRIPTION
When I was trying to add a contribution to your project I found few issues which may be troubling for other users that want to contribute:

- git submodule URL should not be a SSH url because not everyone setup SSH keys in GitHub, Godot repository is public and HTTPS will work for everyone and there will be no problems with checking out submodule (even in CI)
- prettier was not listed as a dev dependency in `package.json` and `lint-staged` script was not working for me
- prettier was formatting generated code in `_godot_defs` directory what caused a lot of changes in definition files, I've added `.prettierignore` with that directory because I think that generated code should not be additionally formatted 