### PR TITLE
Fix crash when renaming or deleting a file

### DIFF
--- a/project/project.ts
+++ b/project/project.ts
@@ -356,6 +356,10 @@ export const makeTsGdProject = async (
           // Chokidar is inconsistent about whether it passes in stats or not -
           // sometimes it does and sometimes it doesn't.
 
+          if (!fs.existsSync(path)) {
+            return true
+          }
+
           return !shouldIncludePath(path, stats ?? fs.statSync(path))
         },
       })

--- a/project/project.ts
+++ b/project/project.ts
@@ -353,13 +353,12 @@ export const makeTsGdProject = async (
     const watcher: chokidar.FSWatcher = chokidar
       .watch(ts2gdJson.rootPath, {
         ignored: (path: string, stats?: fs.Stats) => {
-          // Chokidar is inconsistent about whether it passes in stats or not -
-          // sometimes it does and sometimes it doesn't.
-
           if (!fs.existsSync(path)) {
             return true
           }
 
+          // Chokidar is inconsistent about whether it passes in stats or not -
+          // sometimes it does and sometimes it doesn't.
           return !shouldIncludePath(path, stats ?? fs.statSync(path))
         },
       })

--- a/project/project.ts
+++ b/project/project.ts
@@ -353,13 +353,12 @@ export const makeTsGdProject = async (
     const watcher: chokidar.FSWatcher = chokidar
       .watch(ts2gdJson.rootPath, {
         ignored: (path: string, stats?: fs.Stats) => {
-          if (!fs.existsSync(path)) {
-            return true
-          }
-
           // Chokidar is inconsistent about whether it passes in stats or not -
           // sometimes it does and sometimes it doesn't.
-          return !shouldIncludePath(path, stats ?? fs.statSync(path))
+          return !shouldIncludePath(
+            path,
+            stats ?? (fs.existsSync(path) ? fs.statSync(path) : undefined)
+          )
         },
       })
       .on("add", addFn)
@@ -372,7 +371,7 @@ export const makeTsGdProject = async (
   return new TsGdProjectClass(watcher, initialFiles, program, ts2gdJson, args)
 }
 
-const shouldIncludePath = (path: string, stats: fs.Stats): boolean => {
+const shouldIncludePath = (path: string, stats?: fs.Stats): boolean => {
   if (path.includes("node_modules")) {
     return false
   }
@@ -393,7 +392,7 @@ const shouldIncludePath = (path: string, stats: fs.Stats): boolean => {
     return false
   }
 
-  if (stats.isDirectory()) {
+  if (stats && stats.isDirectory()) {
     return true
   }
 


### PR DESCRIPTION
Fixed a crash when file was renamed or deleted.

Crash dump:
```ts
node:fs:1536
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, stat '/home/adam/Documents/git/adamuso/test-project/scripts/src/Test.ts'
    at Object.statSync (node:fs:1536:3)
    at ignored (/home/adam/Documents/git/adamuso/ts2gd/js/project/project.js:260:71)
    at matchPatterns (/home/adam/Documents/git/adamuso/ts2gd/node_modules/anymatch/index.js:62:18)
    at FSWatcher._userIgnored (/home/adam/Documents/git/adamuso/ts2gd/node_modules/anymatch/index.js:96:14)
    at FSWatcher._isIgnored (/home/adam/Documents/git/adamuso/ts2gd/node_modules/chokidar/index.js:779:15)
    at FSWatcher._remove (/home/adam/Documents/git/adamuso/ts2gd/node_modules/chokidar/index.js:895:27)
    at listener (/home/adam/Documents/git/adamuso/ts2gd/node_modules/chokidar/lib/nodefs-handler.js:381:18) {
  errno: -2,
  syscall: 'stat',
  code: 'ENOENT',
  path: '/home/adam/Documents/git/adamuso/test-project/scripts/src/Test.ts'
}
```

closes #48 