### PR TITLE
Add static method support

### DIFF
--- a/parse_node/parse_method_declaration.ts
+++ b/parse_node/parse_method_declaration.ts
@@ -20,6 +20,7 @@ export const parseMethodDeclaration = (
 
   let isRemote = false
   let isRemoteSync = false
+  let isStatic = node.modifiers?.some((v) => v.getText() === "static") ?? false
 
   for (const dec of node.decorators ?? []) {
     if (dec.expression.getText() === "remote") {
@@ -67,8 +68,8 @@ export const parseMethodDeclaration = (
       body = bodyLines.map((line) => "  " + line + "\n").join("")
 
       return `
-${isRemote ? "remote " : ""}${
-        isRemoteSync ? "remotesync " : ""
+${isRemote ? "remote " : ""}${isRemoteSync ? "remotesync " : ""}${
+        isStatic ? "static " : ""
       }func ${funcName}(${joinedParams}):
 ${body.trim() === "" ? "pass" : body}
 `
@@ -156,4 +157,19 @@ func testDefault(a = "[no value passed in]", b = "[no value passed in]"):
   a = (1 if (typeof(a) == TYPE_STRING and a == "[no value passed in]") else a)
   b = (a if (typeof(b) == TYPE_STRING and b == "[no value passed in]") else b)
 `,
+}
+
+export const testStaticMethod: Test = {
+  ts: `
+export class Foo extends Node2D {
+  static staticMethod() {}
+}
+  `,
+  expected: `
+extends Node2D
+class_name Foo
+
+static func staticMethod():
+  pass
+  `,
 }

--- a/ts_utils.ts
+++ b/ts_utils.ts
@@ -441,3 +441,17 @@ export const getTimestamp = () => {
 
   return `[${h}:${m}:${s}]`
 }
+
+export const findContainingClassDeclaration = (
+  node: ts.Node
+): ts.ClassDeclaration | null => {
+  while (
+    !ts.isClassDeclaration(node) &&
+    !ts.isSourceFile(node) &&
+    node.parent
+  ) {
+    node = node.parent
+  }
+
+  return ts.isClassDeclaration(node) ? node : null
+}


### PR DESCRIPTION
Add support for static methods in classes. Simple as that.
```ts
class Test extends Area2D {
  constructor() {
    super()
    Test.test()
  }

  static test() {
    print("static")
  }
}
```
```ts
import { Test } from "./src/Test"

class Foo extends Node { 
  constructor() {
    super()
    Test.test()
  }
}
```
```gdscript
extends Area2D
class_name Test

func _ready():
  self.test()

static func test():
  print("static")
```
```gdscript
extends Node
class_name Foo

var Test = load("res://compiled/Test.gd")

func _ready():
  Test.test()
```

closes #69 