### PR TITLE
Fix crashing when non existing asset file is removed 

### DIFF
--- a/project/assets/asset_source_file.ts
+++ b/project/assets/asset_source_file.ts
@@ -207,7 +207,7 @@ Hint: try ${chalk.blueBright(
       location: ast ?? this.tsRelativePath,
       stack: new Error().stack ?? "",
       description: `Can't find the autoload instance variable for this autoload class. All files with an autoload class must export an instance of that class. Here's an example:
-        
+
 @autoload
 class MyAutoloadClass extends Node2D {
   public string hello = "hi"
@@ -302,8 +302,8 @@ ${chalk.green(
               description: `You have two classes named ${
                 this.name
               } in the same folder. ts2gd saves every class as "class_name.gd", so they will overwrite each other. We recommend renaming one, but you can also move it into a new directory.
-              
-First path:  ${chalk.yellow(this.fsPath)}              
+
+First path:  ${chalk.yellow(this.fsPath)}
 Second path: ${chalk.yellow(sf.fsPath)}`,
               error: ErrorName.TwoClassesWithSameName,
               location: sourceFile,
@@ -421,7 +421,7 @@ Second path: ${chalk.yellow(sf.fsPath)}`,
 
 ${chalk.white(
   `export const ${this.getGodotClassName()} = new ${this.exportedTsClassName()}()`
-)}        
+)}
         `,
         location: classNode ?? this.fsPath,
         stack: new Error().stack ?? "",
@@ -521,7 +521,7 @@ ${chalk.white(
 
   destroy() {
     // Delete the .gd file
-    fs.rmSync(this.gdPath)
+    fs.rmSync(this.gdPath, { force: true })
 
     // Delete the generated enum files
     const filesInDirectory = fs.readdirSync(this.gdContainingDirectory)
@@ -531,7 +531,7 @@ ${chalk.white(
       const fullPath = this.gdContainingDirectory + fileName
 
       if (fullPath.startsWith(nameWithoutExtension)) {
-        fs.rmSync(fullPath)
+        fs.rmSync(fullPath, { force: true })
       }
     }
 


### PR DESCRIPTION
Sometimes when file is copied and then renamed `rmSync` throws exception because it tries to remove non-existing file (trace below). This PR adds `force: true` to `rmSync` to ignore those exceptions.

```
TS can't find source file /home/adam/Documents/git/adamuso/test-project/scripts/src/BaseNode copy.ts after waiting 1 second. Try saving your TypeScript file again.
Delete:  /home/adam/Documents/git/adamuso/test-project/scripts/src/BaseNode copy.ts
node:internal/fs/utils:344
    throw err;
    ^

Error: ENOENT: no such file or directory, stat '/home/adam/Documents/git/adamuso/test-project/scripts/compiled/BaseNode copy.gd'
    at Object.statSync (node:fs:1536:3)
    at __node_internal_ (node:internal/fs/utils:793:8)
    at Object.rmSync (node:fs:1211:13)
    at AssetSourceFile.destroy (/home/adam/Documents/git/adamuso/ts2gd/js/project/assets/asset_source_file.js:389:22)
    at TsGdProjectClass.onRemoveAsset (/home/adam/Documents/git/adamuso/ts2gd/js/project/project.js:196:26)
    at FSWatcher.<anonymous> (/home/adam/Documents/git/adamuso/ts2gd/js/project/project.js:116:42)
    at FSWatcher.emit (node:events:390:28)
    at /home/adam/Documents/git/adamuso/ts2gd/node_modules/chokidar/index.js:581:16
    at Map.forEach (<anonymous>)
    at Timeout._onTimeout (/home/adam/Documents/git/adamuso/ts2gd/node_modules/chokidar/index.js:580:30) {
  errno: -2,
  syscall: 'stat',
  code: 'ENOENT',
  path: '/home/adam/Documents/git/adamuso/test-project/scripts/compiled/BaseNode copy.gd'
}
```