### PR TITLE
fix main awaits

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     "**/dummy/**",
     "**/godot_src/**",
     "**/js/**",
+    ".eslintrc.js",
   ],
   env: {
     es2021: true,
@@ -18,6 +19,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 13,
     sourceType: "module",
+    project: "./tsconfig.json",
   },
   plugins: ["import", "prettier", "@typescript-eslint"],
   rules: {
@@ -25,6 +27,7 @@ module.exports = {
     "import/first": "error",
     "import/no-duplicates": "error",
     "import/order": ["error", { "newlines-between": "always" }],
+    "@typescript-eslint/no-floating-promises": "error",
     // we could look into turning these on
     "prefer-const": "off",
     "@typescript-eslint/no-empty-function": "off",

--- a/errors.ts
+++ b/errors.ts
@@ -59,7 +59,7 @@ export const displayErrors = (args: ParsedArgs, message: string) => {
     console.info()
     console.info(chalk.greenBright("No errors."))
 
-    return
+    return false
   }
 
   console.info(message)
@@ -100,6 +100,7 @@ export const displayErrors = (args: ParsedArgs, message: string) => {
   }
 
   errors = []
+  return true
 }
 
 export const __getErrorsTestOnly = () => {

--- a/project/project.ts
+++ b/project/project.ts
@@ -159,7 +159,9 @@ export class TsGdProject {
 
         displayErrors(this.args, message)
       })
-      .on("unlink", (path) => this.onRemoveAsset(path))
+      .on("unlink", async (path) => {
+        await this.onRemoveAsset(path)
+      })
   }
 
   async onAddAsset(path: string): Promise<string> {
@@ -255,7 +257,7 @@ export class TsGdProject {
     return message
   }
 
-  onRemoveAsset(path: string) {
+  async onRemoveAsset(path: string) {
     console.info("Delete:\t", path)
 
     const changedAsset = this.assets.find((asset) => asset.fsPath === path)
@@ -265,7 +267,7 @@ export class TsGdProject {
     }
 
     if (changedAsset instanceof AssetSourceFile) {
-      changedAsset.destroy()
+      await changedAsset.destroy()
     }
 
     this.assets = this.assets.filter((asset) => asset !== changedAsset)

--- a/project/project.ts
+++ b/project/project.ts
@@ -271,15 +271,18 @@ export class TsGdProject {
     this.assets = this.assets.filter((asset) => asset !== changedAsset)
   }
 
-  async compileAllSourceFiles() {
+  /**
+   * Compile all current source files
+   * @returns false if the compilation had errors, true otherwise
+   */
+  async compileAllSourceFiles(): Promise<boolean> {
     const assetsToCompile = this.assets.filter(
       (a): a is AssetSourceFile => a instanceof AssetSourceFile
     )
     await Promise.all(
       assetsToCompile.map((asset) => asset.compile(this.program))
     )
-
-    displayErrors(this.args, "Compiling all source files...")
+    return !displayErrors(this.args, "Compiling all source files...")
   }
 
   shouldBuildLibraryDefinitions(flags: ParsedArgs) {

--- a/tests/project_tests.ts
+++ b/tests/project_tests.ts
@@ -1,7 +1,7 @@
 import { main } from "../main"
 
-export const test = () => {
-  main({
+export async function test() {
+  return main({
     buildLibraries: false,
     help: false,
     init: false,
@@ -11,4 +11,11 @@ export const test = () => {
   })
 }
 
-test()
+void (async () => {
+  try {
+    await test()
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+})()

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -123,7 +123,7 @@ export const compileTs = (code: string, isAutoload: boolean): ParseNodeType => {
       monitor: () => 0 as any,
       onAddAsset: async () => "",
       onChangeAsset: async () => "",
-      onRemoveAsset: () => {},
+      onRemoveAsset: async () => {},
       sourceFiles: () => [
         {
           exportedTsClassName: () => "",

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -90,7 +90,7 @@ export const compileTs = (code: string, isAutoload: boolean): ParseNodeType => {
       buildDynamicDefinitions: async () => {},
       assets: [],
       program: undefined as any,
-      compileAllSourceFiles: async () => {},
+      compileAllSourceFiles: async () => true,
       shouldBuildLibraryDefinitions: () => false,
       validateAutoloads: () => [],
       buildLibraryDefinitions: async () => {},
@@ -529,4 +529,11 @@ export const runTests = async () => {
   }
 }
 
-runTests()
+void (async () => {
+  try {
+    await runTests()
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+})


### PR DESCRIPTION
Currently the main process didn't correctly call the await and was silently swallowing errors like the EACCESS ones from the bloodfever ci builds: https://github.com/KronbergerSpiele/bloodfever/runs/4633955575?check_suite_focus=true#step:6:292

Related to #51 (It isn't a fix for that, but now shows the correct error, which I currently think is unrelated)

I did add a lint rule to avoid these issues in the future.

Additionally use the promised version in the source compilation path to streamline error handling.