### PR TITLE
import package.json by module

### DIFF
--- a/check_version.ts
+++ b/check_version.ts
@@ -1,11 +1,17 @@
 import https from "https"
 
 import chalk from "chalk"
+import pkginfo from "pkginfo"
 
-import packageJson from "./package.json"
+pkginfo(module, "version")
+
+export function getInstalledVersion() {
+  return module.exports.version as string
+}
 
 export const checkVersionAsync = async () => {
-  console.info(chalk.whiteBright("ts2gd", "v" + packageJson.version))
+  const version = getInstalledVersion()
+  console.info(chalk.whiteBright("ts2gd", "v" + version))
 
   const options = {
     hostname: "registry.npmjs.org",
@@ -47,10 +53,10 @@ export const checkVersionAsync = async () => {
     break
   }
 
-  if (latestPublishedVersion !== packageJson.version) {
+  if (latestPublishedVersion !== version) {
     console.info(``)
     console.info(
-      `There is a new version (${latestPublishedVersion}) of ts2gd. (You have ${packageJson.version}.)`
+      `There is a new version (${latestPublishedVersion}) of ts2gd. (You have ${version}.)`
     )
     console.info(`Install it with`)
     console.info(``)

--- a/main.ts
+++ b/main.ts
@@ -157,9 +157,8 @@ import chalk from "chalk"
 
 import { ParsedArgs, parseArgs, printHelp } from "./parse_args"
 import { Paths } from "./project/paths"
-import { checkVersionAsync } from "./check_version"
+import { checkVersionAsync, getInstalledVersion } from "./check_version"
 import { makeTsGdProject } from "./project/project"
-import packageJson from "./package.json"
 
 const setup = (tsgdJson: Paths) => {
   const formatHost: ts.FormatDiagnosticsHost = {
@@ -247,6 +246,8 @@ const setup = (tsgdJson: Paths) => {
   }
 }
 
+const version = getInstalledVersion()
+
 export const showLoadingMessage = (
   msg: string,
   args: ParsedArgs,
@@ -254,9 +255,7 @@ export const showLoadingMessage = (
 ) => {
   if (!args.debug) console.clear()
   console.info(
-    `${chalk.whiteBright("ts2gd v" + packageJson.version)}: ${
-      msg + (done ? "" : "...")
-    }`
+    `${chalk.whiteBright("ts2gd v" + version)}: ${msg + (done ? "" : "...")}`
   )
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
+        "pkginfo": "^0.4.1",
         "tsutils": "^3.21.0",
         "xml2js": "^0.4.23"
       },
@@ -19,6 +20,7 @@
       },
       "devDependencies": {
         "@types/node": "^16.11.9",
+        "@types/pkginfo": "^0.4.0",
         "@types/xml2js": "^0.4.9",
         "@typescript-eslint/eslint-plugin": "^5.7.0",
         "@typescript-eslint/parser": "^5.7.0",
@@ -182,6 +184,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
       "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A==",
       "dev": true
+    },
+    "node_modules/@types/pkginfo": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/pkginfo/-/pkginfo-0.4.0.tgz",
+      "integrity": "sha512-4DGKkOlWkMuVDZQvytWzzWWAjyqDmlLKRYE4lzeA8t0s7fK0aF25uPbX9eBVermUjLJdeLHu9k1WmNiAssqCcg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/strip-bom": {
       "version": "3.0.0",
@@ -2596,6 +2607,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3547,6 +3566,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
       "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A==",
       "dev": true
+    },
+    "@types/pkginfo": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/pkginfo/-/pkginfo-0.4.0.tgz",
+      "integrity": "sha512-4DGKkOlWkMuVDZQvytWzzWWAjyqDmlLKRYE4lzeA8t0s7fK0aF25uPbX9eBVermUjLJdeLHu9k1WmNiAssqCcg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/strip-bom": {
       "version": "3.0.0",
@@ -5281,6 +5309,11 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
+    "pkginfo": "^0.4.1",
     "tsutils": "^3.21.0",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@types/node": "^16.11.9",
+    "@types/pkginfo": "^0.4.0",
     "@types/xml2js": "^0.4.9",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",


### PR DESCRIPTION
has the advantage of not copying the package.json into the js/ folder on build. Which can confuse jest with the presence of two package.jsons